### PR TITLE
Add cookbook name to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "grunt_cookbook"
 maintainer       "Matt Surabian"
 maintainer_email "matt@mattsurabian.com"
 license          "MIT"


### PR DESCRIPTION
It looks like this is required for compatibility with Chef 12: https://github.com/chef/chef/issues/2435#issuecomment-63350307

```
[2015-05-07T19:16:29-04:00] ERROR: Cookbook loaded at path(s) [/root/chef-solo/cookbooks-2/grunt_cookbook] has invalid metadata: The `name' attribute is required in cookbook metadata
```
